### PR TITLE
feat: add SEO head components

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,51 +1,60 @@
 import * as React from "react"
-import { useStaticQuery, graphql } from 'gatsby'
-import styled from 'styled-components'
+import { useStaticQuery, graphql } from "gatsby"
+import styled from "styled-components"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 
-const NotFoundPage = () => {
+const NotFoundPage = () => (
+  <Layout>
+    <MainSection>
+      <div>
+        <h1>404: Not Found</h1>
+        <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      </div>
+    </MainSection>
+  </Layout>
+)
 
+export const Head = () => {
   const data = useStaticQuery(graphql`
     query {
-        jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
-            childImageSharp {
-                gatsbyImageData(
-                  width: 800
-                  placeholder: TRACED_SVG
-                  formats: [AUTO, WEBP, AVIF]
-                )
-                fluid(maxWidth: 800, quality: 100) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-              }
+      jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
+        childImageSharp {
+          gatsbyImageData(
+            width: 800
+            placeholder: TRACED_SVG
+            formats: [AUTO, WEBP, AVIF]
+          )
+          fluid(maxWidth: 800, quality: 100) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
         }
+      }
     }
   `)
 
-  return(
-    <Layout>
-      <Seo 
-        title={"404: Not Found | The Remote Creative"} 
-        description={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        keywords={"Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"}
-        ogTitle={"404: Not Found | The Remote Creative"} 
-        ogDescription={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        ogImage={data.jasonThumb.childImageSharp.fluid}
-        twitterTitle={"404: Not Found | The Remote Creative"} 
-        twitterDescription={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        twitterImage={data.jasonThumb.childImageSharp.fluid}
-        />
-        <MainSection>
-          <div>
-            <h1>404: Not Found</h1>
-            <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-          </div>
-        </MainSection>
-    </Layout>
-  );
-  
+  return (
+    <Seo
+      title={"404: Not Found | The Remote Creative"}
+      description={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      keywords={
+        "Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"
+      }
+      ogTitle={"404: Not Found | The Remote Creative"}
+      ogDescription={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      ogImage={data.jasonThumb.childImageSharp.fluid}
+      twitterTitle={"404: Not Found | The Remote Creative"}
+      twitterDescription={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      twitterImage={data.jasonThumb.childImageSharp.fluid}
+    />
+  )
 }
 
 const MainSection = styled.section`
@@ -55,49 +64,49 @@ const MainSection = styled.section`
   display: flex;
   justify-content: center;
   align-items: center;
-    h1 {
-      font-family: Roboto;
-      font-weight: 900;
-      font-size: 72px;
-      line-height: 1.2;
-      color: #fff;
-      max-width: 960px;
-      text-shadow: 2px 2px 4px rgba(0,0,0,.5);
-      transform: translateZ(60px);
-      transition-duration: .3s;
-      text-align: center;
-      &:hover {
-          transform: translateZ(120px);
-      }
+  h1 {
+    font-family: Roboto;
+    font-weight: 900;
+    font-size: 72px;
+    line-height: 1.2;
+    color: #fff;
+    max-width: 960px;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+    transform: translateZ(60px);
+    transition-duration: 0.3s;
+    text-align: center;
+    &:hover {
+      transform: translateZ(120px);
+    }
   }
   p {
-      font-family: Poppins;
-      font-weight: 400;
+    font-family: Poppins;
+    font-weight: 400;
+    font-size: 36px;
+    line-height: 1.3;
+    max-width: 500px;
+    color: #fff;
+    transform: translateZ(60px);
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+    text-align: center;
+  }
+  @media (max-width: 960px) {
+    h1 {
+      font-size: 56px;
+    }
+    p {
+      margin: 0 auto;
+      font-size: 32px;
+    }
+  }
+  @media (max-width: 767px) {
+    h1 {
       font-size: 36px;
-      line-height: 1.3;
-      max-width: 500px;
-      color: #fff;
-      transform: translateZ(60px);
-      text-shadow: 1px 1px 2px rgba(0,0,0,.5);
-      text-align: center;
-  }
-  @media(max-width:960px) {
-      h1 {
-          font-size: 56px;
-      }
-      p {
-          margin: 0 auto;
-          font-size: 32px;
-      }
-  }
-  @media(max-width:767px) {
-      h1 {
-          font-size: 36px;
-      }
-      p {
-          margin: 0 auto;
-          font-size: 24px;
-      }
+    }
+    p {
+      margin: 0 auto;
+      font-size: 24px;
+    }
   }
 `
 

--- a/src/pages/gatsby.js
+++ b/src/pages/gatsby.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { useStaticQuery, graphql } from 'gatsby'
+import { useStaticQuery, graphql } from "gatsby"
 
 import SubLayout from "../components/sub-layout"
 import Seo from "../components/seo"
@@ -8,45 +8,54 @@ import GatsbyTwo from "../components/gatsby-two"
 import GatsbyPortfolio from "../components/gatsby-portfolio"
 import GatsbyContact from "../components/gatsby-contact"
 
-const GatsbyPage = () => {
+const GatsbyPage = () => (
+  <SubLayout>
+    <GatsbyOne />
+    <GatsbyTwo />
+    <GatsbyPortfolio />
+    <GatsbyContact />
+  </SubLayout>
+)
 
+export default GatsbyPage
+
+export const Head = () => {
   const data = useStaticQuery(graphql`
     query {
-        jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
-            childImageSharp {
-                gatsbyImageData(
-                  width: 800
-                  placeholder: TRACED_SVG
-                  formats: [AUTO, WEBP, AVIF]
-                )
-                fluid(maxWidth: 800, quality: 100) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-              }
+      jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
+        childImageSharp {
+          gatsbyImageData(
+            width: 800
+            placeholder: TRACED_SVG
+            formats: [AUTO, WEBP, AVIF]
+          )
+          fluid(maxWidth: 800, quality: 100) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
         }
+      }
     }
   `)
 
-  return(
-    <SubLayout>
-      <Seo 
-        title={"Gatsby.js Website Development | The Remote Creative"} 
-        description={"Gatsby website development. Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."}
-        keywords={"gatsby website development, Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"}
-        ogTitle={"Gatsby.js Website Development | The Remote Creative"} 
-        ogDescription={"Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."}
-        ogImage={data.jasonThumb.childImageSharp.fluid}
-        twitterTitle={"Gatsby.js Website Development | The Remote Creative"} 
-        twitterDescription={"Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."}
-        twitterImage={data.jasonThumb.childImageSharp.fluid}
-      />
-      <GatsbyOne/>
-      <GatsbyTwo/>
-      <GatsbyPortfolio/>
-      <GatsbyContact/>
-    </SubLayout>
-  );
-  
+  return (
+    <Seo
+      title={"Gatsby.js Website Development | The Remote Creative"}
+      description={
+        "Gatsby website development. Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."
+      }
+      keywords={
+        "gatsby website development, Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"
+      }
+      ogTitle={"Gatsby.js Website Development | The Remote Creative"}
+      ogDescription={
+        "Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."
+      }
+      ogImage={data.jasonThumb.childImageSharp.fluid}
+      twitterTitle={"Gatsby.js Website Development | The Remote Creative"}
+      twitterDescription={
+        "Combine the Gatsby.js framework with the WordPress dashboard to create a lightning fast, App-like, and secure website."
+      }
+      twitterImage={data.jasonThumb.childImageSharp.fluid}
+    />
+  )
 }
-
-export default GatsbyPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { useStaticQuery, graphql } from 'gatsby'
+import { useStaticQuery, graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
@@ -9,45 +9,54 @@ import SectionTwo from "../components/home-components/section-two"
 import PortfolioSection from "../components/home-components/portfolio-section"
 import AboutSection from "../components/home-components/about-section"
 
-const IndexPage = () => {
+const IndexPage = () => (
+  <Layout>
+    <HeroSection />
+    <SectionTwo />
+    <PortfolioSection />
+    <AboutSection />
+  </Layout>
+)
 
+export default IndexPage
+
+export const Head = () => {
   const data = useStaticQuery(graphql`
     query {
-        jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
-            childImageSharp {
-                gatsbyImageData(
-                  width: 800
-                  placeholder: TRACED_SVG
-                  formats: [AUTO, WEBP, AVIF]
-                )
-                fluid(maxWidth: 800, quality: 100) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-              }
+      jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
+        childImageSharp {
+          gatsbyImageData(
+            width: 800
+            placeholder: TRACED_SVG
+            formats: [AUTO, WEBP, AVIF]
+          )
+          fluid(maxWidth: 800, quality: 100) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
         }
+      }
     }
   `)
 
-  return(
-    <Layout>
-      <Seo 
-        title={"Home | The Remote Creative"} 
-        description={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        keywords={"gatsby website development, Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"}
-        ogTitle={"Home | The Remote Creative"} 
-        ogDescription={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        ogImage={data.jasonThumb.childImageSharp.fluid}
-        twitterTitle={"Home | The Remote Creative"} 
-        twitterDescription={"Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."}
-        twitterImage={data.jasonThumb.childImageSharp.fluid}
-        />
-      <HeroSection />
-      <SectionTwo />
-      <PortfolioSection />
-      <AboutSection />
-    </Layout>
-  );
-
+  return (
+    <Seo
+      title={"Home | The Remote Creative"}
+      description={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      keywords={
+        "gatsby website development, Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"
+      }
+      ogTitle={"Home | The Remote Creative"}
+      ogDescription={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      ogImage={data.jasonThumb.childImageSharp.fluid}
+      twitterTitle={"Home | The Remote Creative"}
+      twitterDescription={
+        "Modern Web Development with WordPress and Gatsby.js. Building lightning fast web apps with the latest react libraries and content management systems."
+      }
+      twitterImage={data.jasonThumb.childImageSharp.fluid}
+    />
+  )
 }
-
-export default IndexPage

--- a/src/pages/project-portfolio.js
+++ b/src/pages/project-portfolio.js
@@ -1,46 +1,55 @@
 import React from "react"
-import { useStaticQuery, graphql } from 'gatsby'
+import { useStaticQuery, graphql } from "gatsby"
 
 import SubLayout from "../components/sub-layout"
 import Seo from "../components/seo"
 import FeaturedPortfolio from "../components/featured-portfolio"
 
-const ProjectPage = () => {
+const ProjectPage = () => (
+  <SubLayout>
+    <FeaturedPortfolio />
+  </SubLayout>
+)
 
+export default ProjectPage
+
+export const Head = () => {
   const data = useStaticQuery(graphql`
     query {
-        jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
-            childImageSharp {
-                gatsbyImageData(
-                  width: 800
-                  placeholder: TRACED_SVG
-                  formats: [AUTO, WEBP, AVIF]
-                )
-                fluid(maxWidth: 800, quality: 100) {
-                  ...GatsbyImageSharpFluid_withWebp
-                }
-              }
+      jasonThumb: file(relativePath: { eq: "Jason-Vanderheyden.jpg" }) {
+        childImageSharp {
+          gatsbyImageData(
+            width: 800
+            placeholder: TRACED_SVG
+            formats: [AUTO, WEBP, AVIF]
+          )
+          fluid(maxWidth: 800, quality: 100) {
+            ...GatsbyImageSharpFluid_withWebp
+          }
         }
+      }
     }
   `)
 
-  return(
-    <SubLayout>
-      <Seo 
-        title={"Project Portfolio | The Remote Creative"} 
-        description={"Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."}
-        keywords={"Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"}
-        ogTitle={"Project Portfolio | The Remote Creative"} 
-        ogDescription={"Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."}
-        ogImage={data.jasonThumb.childImageSharp.fluid}
-        twitterTitle={"Project Portfolio | The Remote Creative"} 
-        twitterDescription={"Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."}
-        twitterImage={data.jasonThumb.childImageSharp.fluid}
-      />
-      <FeaturedPortfolio/>
-    </SubLayout>
-  );
-
+  return (
+    <Seo
+      title={"Project Portfolio | The Remote Creative"}
+      description={
+        "Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."
+      }
+      keywords={
+        "Gatsby.js, WordPress, GSAP, GreenSock, Modern Web Development, Fast Websites, Headless CMS, A/B Testing, Split Testing"
+      }
+      ogTitle={"Project Portfolio | The Remote Creative"}
+      ogDescription={
+        "Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."
+      }
+      ogImage={data.jasonThumb.childImageSharp.fluid}
+      twitterTitle={"Project Portfolio | The Remote Creative"}
+      twitterDescription={
+        "Modern Web Development with WordPress and Gatsby.js. View all of my latest projects and contact me if you're interested in working together."
+      }
+      twitterImage={data.jasonThumb.childImageSharp.fluid}
+    />
+  )
 }
-
-export default ProjectPage

--- a/src/pages/using-typescript.tsx
+++ b/src/pages/using-typescript.tsx
@@ -13,7 +13,6 @@ type DataProps = {
 
 const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
   <Layout>
-    <Seo title="Using TypeScript" />
     <h1>Gatsby supports TypeScript by default!</h1>
     <p>
       This means that you can create and write <em>.ts/.tsx</em> files for your
@@ -40,6 +39,8 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
 )
 
 export default UsingTypescript
+
+export const Head = () => <Seo title="Using TypeScript" />
 
 export const query = graphql`
   {

--- a/src/templates/using-dsg.js
+++ b/src/templates/using-dsg.js
@@ -6,7 +6,6 @@ import Seo from "../components/seo"
 
 const UsingDSG = () => (
   <Layout>
-    <Seo title="Using DSG" />
     <h1>Hello from a DSG Page</h1>
     <p>This page is not created until requested by a user.</p>
     <p>
@@ -21,3 +20,5 @@ const UsingDSG = () => (
 )
 
 export default UsingDSG
+
+export const Head = () => <Seo title="Using DSG" />


### PR DESCRIPTION
## Summary
- ensure SEO metadata in document head for all pages by exporting Head with Seo component

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*

------
https://chatgpt.com/codex/tasks/task_b_68a266e0eed883269b49202b4da66ec2