### PR TITLE
chore: remove duplicate gatsby-plugin-image

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,7 +16,6 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
-    `gatsby-plugin-image`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-styled-components`,


### PR DESCRIPTION
## Summary
- remove duplicate `gatsby-plugin-image` from plugin list

## Testing
- `npm test` *(fails: Write tests! -> https://gatsby.dev/unit-testing)*
- `npm ci` *(fails: npm error ... lmdb-store ...)*
- `npm run develop` *(fails: gatsby: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a33f3734a883269be6e266b353c5d1